### PR TITLE
Fix IDE plugin focus, keyboard shortcuts, and icon size

### DIFF
--- a/hosts/jetbrains-plugin/src/main/kotlin/paviko/opencode/ui/PathInserter.kt
+++ b/hosts/jetbrains-plugin/src/main/kotlin/paviko/opencode/ui/PathInserter.kt
@@ -1,9 +1,8 @@
 package paviko.opencode.ui
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
-import com.intellij.ui.jcef.JBCefBrowser
+import com.intellij.openapi.wm.ToolWindowManager
 import javax.swing.SwingUtilities
 
 /**
@@ -11,13 +10,13 @@ import javax.swing.SwingUtilities
  */
 object PathInserter {
     private val logger = Logger.getInstance(PathInserter::class.java)
-    private val mapper = jacksonObjectMapper()
 
     fun insertPaths(project: Project, paths: List<String>) {
         try {
             if (paths.isEmpty()) return
             
             IdeBridge.send(project, "insertPaths", mapOf("paths" to paths))
+            activateToolWindow(project)
         } catch (e: Exception) {
             logger.error("Unexpected error inserting paths", e)
         }
@@ -28,8 +27,19 @@ object PathInserter {
             if (path.isEmpty()) return
             
             IdeBridge.send(project, "pastePath", mapOf("path" to path))
+            activateToolWindow(project)
         } catch (e: Exception) {
             logger.error("Unexpected error pasting path", e)
+        }
+    }
+
+    private fun activateToolWindow(project: Project) {
+        SwingUtilities.invokeLater {
+            try {
+                val toolWindow = ToolWindowManager.getInstance(project).getToolWindow("OpenCode")
+                toolWindow?.show(null)
+                toolWindow?.activate(null, true)
+            } catch (_: Throwable) {}
         }
     }
 }

--- a/hosts/jetbrains-plugin/src/main/resources/icons/opencodeToolWindow.svg
+++ b/hosts/jetbrains-plugin/src/main/resources/icons/opencodeToolWindow.svg
@@ -1,6 +1,6 @@
-<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M22 12H74C81.1797 12 86 16.8203 86 24V60C86 67.1797 81.1797 72 74 72H58L48 84L38 72H22C14.8203 72 10 67.1797 10 60V24C10 16.8203 14.8203 12 22 12Z" stroke="#555F6C" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M30 30H50" stroke="#555F6C" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M54 42H68C71.3137 42 74 44.6863 74 48C74 51.3137 71.3137 54 68 54H58" stroke="#555F6C" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M36 54H50" stroke="#555F6C" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="13" height="13" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 2H10C10.8 2 11.5 2.7 11.5 3.5V8C11.5 8.8 10.8 9.5 10 9.5H8L6.5 11L5 9.5H3C2.2 9.5 1.5 8.8 1.5 8V3.5C1.5 2.7 2.2 2 3 2Z" stroke="#6B7280" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M4 4.5H6.5" stroke="#6B7280" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M7 6H9C9.3 6 9.5 6.2 9.5 6.5C9.5 6.8 9.3 7 9 7H7.5" stroke="#6B7280" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M5 7.5H6.5" stroke="#6B7280" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/packages/opencode/webgui/src/App.tsx
+++ b/packages/opencode/webgui/src/App.tsx
@@ -126,14 +126,14 @@ function AppInner({ connectionState }: { connectionState: ConnectionState }) {
         const paths = (msg.payload?.paths ?? msg.paths) as string[] | undefined
         if (Array.isArray(paths) && paths.length > 0) {
           messageInputRef.current?.focus()
-          messageInputRef.current?.insertPaths(paths)
+          queueMicrotask(() => messageInputRef.current?.insertPaths(paths))
         }
       }
       if (msg.type === "pastePath") {
         const path = (msg.payload?.path ?? msg.path) as string | undefined
         if (typeof path === "string" && path.length > 0) {
           messageInputRef.current?.focus()
-          messageInputRef.current?.pastePath(path)
+          queueMicrotask(() => messageInputRef.current?.pastePath(path))
         }
       }
       if (msg.type === "drag-event") {

--- a/packages/opencode/webgui/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/opencode/webgui/src/hooks/useKeyboardShortcuts.ts
@@ -39,7 +39,11 @@ export function useKeyboardShortcuts({
     const handleKeyDown = (e: KeyboardEvent) => {
       const isMod = e.metaKey || e.ctrlKey
       const target = e.target as HTMLElement
-      const isInputField = target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable
+      const isInputField =
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable ||
+        target.closest?.('[contenteditable="true"]') != null
 
       // Escape: Close modal (works everywhere)
       if (e.key === "Escape" && isModalOpen) {


### PR DESCRIPTION
## Bug Fixes

### 1. Auto-focus message input after inserting paths (WebGUI)
- **File**: `packages/opencode/webgui/src/App.tsx`
- **Issue**: `focus()` immediately followed by `insertPaths()` could race with Lexical's internal selection setup
- **Fix**: Use `queueMicrotask()` to defer path insertion until focus settles

### 2. Prevent '?' shortcut in message input (WebGUI)
- **File**: `packages/opencode/webgui/src/hooks/useKeyboardShortcuts.ts`
- **Issue**: `isInputField` only checked `target.isContentEditable`, which is false for child elements inside Lexical editor (e.g. `<p>`, `<span>`, `<br>`)
- **Fix**: Add `closest('[contenteditable="true"]')` detection

### 3. Activate OpenCode toolwindow on path insertion (JetBrains)
- **File**: `hosts/jetbrains-plugin/src/main/kotlin/paviko/opencode/ui/PathInserter.kt`
- **Issue**: Keyboard shortcuts sent paths via IDE bridge but never transferred focus to OpenCode panel
- **Fix**: Add `activateToolWindow()` with `show()` + `activate()` calls after sending message

### 4. Fix oversized sidebar icon (JetBrains)
- **File**: `hosts/jetbrains-plugin/src/main/resources/icons/opencodeToolWindow.svg`
- **Issue**: SVG was 96x96 pixels, far larger than standard JetBrains toolwindow icon size (13x13)
- **Fix**: Scale SVG down to 13x13 with adjusted paths and stroke width